### PR TITLE
feat: support code without semicolons

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,8 +5,8 @@ function escape(str) {
     return str.replace(/[\-\[\]\/\{\}\(\)\*\+\?\.\\\^\$\|]/g, '\\$&')
 }
 module.exports = function rewriteImports(appendPath) {
-    const patternImport = new RegExp(/import(?:["'\s]*([\w*${}\n\r\t, ]+)from\s*)?["'\s]["'\s](.*[@\w_-]+)["'\s].*;$/, 'mg')
-    const patternDImport = new RegExp(/import\((?:["'\s]*([\w*{}\n\r\t, ]+)\s*)?["'\s](.*([@\w_-]+))["'\s].*\);$/, 'mg')
+    const patternImport = new RegExp(/import(?:["'\s]*([\w*${}\n\r\t, ]+)from\s*)?["'\s]["'\s](.*[@\w_-]+)["'\s].*;?$/, 'mg')
+    const patternDImport = new RegExp(/import\((?:["'\s]*([\w*{}\n\r\t, ]+)\s*)?["'\s](.*([@\w_-]+))["'\s].*\);?$/, 'mg')
     return {
         name: 'rewriteImports',
         renderChunk(code) {

--- a/test.js
+++ b/test.js
@@ -1,30 +1,45 @@
 import test from "ava";
 import rollupPluginRewriteImport from "./index";
 
-test("static import from", t => {
+function rollupTestMacro(t, input, expected) {
   const { renderChunk } = rollupPluginRewriteImport("example/");
-  t.deepEqual(renderChunk('import _ from "lodash";'), {
-    code: 'import _ from "example/lodash";'
-  });
-});
+  const processedInput = renderChunk(input);
+  const expectedResult = expected
+    ? {
+        code: expected
+      }
+    : expected;
+  t.deepEqual(processedInput, expectedResult);
+}
+rollupTestMacro.title = (_, input, expected) =>
+  `${input} becomes ${expected}`.trim();
 
-test("static import side effect", async t => {
-  const { renderChunk } = rollupPluginRewriteImport("example/");
-  t.deepEqual(renderChunk('import "side-effect";'), {
-    code: 'import "example/side-effect";'
-  });
-});
-
-test("dynamic import side effect", async t => {
-  const { renderChunk } = rollupPluginRewriteImport("example/");
-  t.deepEqual(renderChunk('import("side-effect");'), {
-    code: 'import("example/side-effect");'
-  });
-});
-
-test("dynamic import var", async t => {
-  const { renderChunk } = rollupPluginRewriteImport("example/");
-  t.deepEqual(renderChunk('const _ = await import("lodash");'), {
-    code: 'const _ = await import("example/lodash");'
-  });
-});
+test(
+  rollupTestMacro,
+  'import _ from "lodash";',
+  'import _ from "example/lodash";'
+);
+test(
+  rollupTestMacro,
+  'import _ from "lodash"',
+  'import _ from "example/lodash"'
+);
+test(rollupTestMacro, 'import "side-effect";', 'import "example/side-effect";');
+test(rollupTestMacro, 'import "side-effect"', 'import "example/side-effect"');
+test(
+  rollupTestMacro,
+  'import("side-effect");',
+  'import("example/side-effect");'
+);
+test(rollupTestMacro, 'import("side-effect")', 'import("example/side-effect")');
+test(
+  rollupTestMacro,
+  'const _ = await import("lodash");',
+  'const _ = await import("example/lodash");'
+);
+test(
+  rollupTestMacro,
+  'const _ = await import("lodash")',
+  'const _ = await import("example/lodash")'
+);
+test(rollupTestMacro, 'let variable = importLikeFunctionName("test")', null);


### PR DESCRIPTION
both
```javascript
import 'lodash';

// and

import 'lodash'
```

are valid javascript

---

add test macro to simplify testing