### PR TITLE
changed method of resolving external dependencies. #6

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,16 +1,16 @@
 # rollup-plugin-rewrite-imports
 
-Pass a string in to rewrite the path of ES module imports and dynamic imports
+Pass a string in to rewrite the path of ES module imports and dynamic imports if the dependency already exists in a separate node_modules directory.
 
 ## Why
 
-This is useful when you have fragmented or disconnected build routines. This can happen 
-when part of 1 application is modularly mixed with another at run time. [HAXcms](https://haxtheweb.org) 
+This is useful when you have fragmented or disconnected build routines. This can happen
+when part of 1 application is modularly mixed with another at run time. [HAXcms](https://haxtheweb.org)
 leverages this plugin to allow theme developers to use the expeced approaches and methods
-they typically find in web component development, yet not break the site given that 
+they typically find in web component development, yet not break the site given that
 the build routine is shipped with that system.
 
-This puts theme developers and platform owners on the same tooling / workflows yet 
+This puts theme developers and platform owners on the same tooling / workflows yet
 work independently of one another.
 
 ## Install
@@ -18,41 +18,35 @@ work independently of one another.
 ```
 $ npm install rollup-plugin-rewrite-imports --save-dev
 ```
+
 or
+
 ```
 $ yarn add rollup-plugin-rewrite-imports --dev
 ```
 
 ## How to use
 
-This is an example usage with autoExternal. In this example, we are assuming that
-everything in package.json should be treated as external (so roll up won't build it).
-
-Next, `rewriteImports` is called in order to forcibly point to the location that we are
+`rewriteImports` is called in order to forcibly point to the location that we are
 actually building these assets into.
+
 ```javascript
-const path = require('path');
-const autoExternal = require('rollup-plugin-auto-external');
-const rewriteImports = require('rollup-plugin-rewrite-imports');
+const path = require("path");
+const autoExternal = require("rollup-plugin-auto-external");
+const rewriteImports = require("rollup-plugin-rewrite-imports");
 const production = true;
 module.exports = function() {
   return {
-    input: 'src/custom.js',
+    input: "src/custom.js",
     treeshake: !!production,
     output: {
       file: `build/custom.amd.js`,
-      format: 'esm',
-      sourcemap: false,
+      format: "esm",
+      sourcemap: false
     },
     plugins: [
-      autoExternal({
-        builtins: false,
-        dependencies: true,
-        packagePath: path.resolve('package.json'),
-        peerDependencies: false,
-      }),
-      rewriteImports(`../../build/es6/node_modules/`),
-    ],
+      rewriteImports(`../../build/es6/node_modules/`)
+    ]
   };
 };
 ```

--- a/index.js
+++ b/index.js
@@ -1,36 +1,55 @@
 /* eslint-disable strict, no-useless-escape, no-cond-assign */
+// @ts-check
 'use strict'
 const MagicString = require('magic-string')
+const fs = require('fs')
+const path = require('path')
 function escape(str) {
     return str.replace(/[\-\[\]\/\{\}\(\)\*\+\?\.\\\^\$\|]/g, '\\$&')
 }
+// Figures out where the correct relative path should
+// based on the output directory and the appendPath
+function rollupOutputDir(opts, appendPath) {
+    let dir = ''
+    if (opts.file) {
+        dir = path.dirname(opts.file)
+    }
+    else if (opts.dir) {
+        dir = path.dirname(opts.dir)
+    }
+    return path.relative(dir, appendPath)
+}
 module.exports = function rewriteImports(appendPath) {
-    const patternImport = new RegExp(/import(?:["'\s]*([\w*${}\n\r\t, ]+)from\s*)?["'\s]["'\s](.*[@\w_-]+)["'\s].*;?$/, 'mg')
-    const patternDImport = new RegExp(/import\((?:["'\s]*([\w*{}\n\r\t, ]+)\s*)?["'\s](.*([@\w_-]+))["'\s].*\);?$/, 'mg')
+    const patternImport = new RegExp(/import(?:["'\s]*([\w*${}\n\r\t, ]+)from\s*)?["'\s]["'\s](.*[@\w_-]+)["'\s].*;$/, 'mg')
+    const patternDImport = new RegExp(/import\((?:["'\s]*([\w*{}\n\r\t, ]+)\s*)?["'\s](.*([@\w_-]+))["'\s].*\);$/, 'mg')
     return {
         name: 'rewriteImports',
-        renderChunk(code) {
+        renderChunk(code, info, opts) {
+            // get the location of the output directory
             const magicString = new MagicString(code)
             let hasReplacements = false
             let match
             let start
             let end
             let replacement
+            function replaceImport() {
+                // see if it exists above
+                if (fs.existsSync(path.join(process.cwd(), rollupOutputDir(opts, appendPath), match[2]))) {
+                    // if it does then replace the import with the supplied path
+                    hasReplacements = true
+                    start = match.index
+                    end = start + match[0].length
+                    replacement = String(match[0].replace(match[2], appendPath + match[2]))
+                    magicString.overwrite(start, end, replacement)
+                }
+            }
             // work against normal imports
             while (match = patternImport.exec(code)) {
-                hasReplacements = true
-                start = match.index
-                end = start + match[0].length
-                replacement = String(match[0].replace(match[2], appendPath + match[2]))
-                magicString.overwrite(start, end, replacement)
+                replaceImport()
             }
             // work against dynamic imports
             while (match = patternDImport.exec(code)) {
-                hasReplacements = true
-                start = match.index
-                end = start + match[0].length
-                replacement = String(match[0].replace(match[2], appendPath + match[2]))
-                magicString.overwrite(start, end, replacement)
+                replaceImport()
             }
             if (!hasReplacements) return null
             const result = { code: magicString.toString() }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "rollup-plugin-rewrite-imports",
-  "version": "1.0.1",
-  "description": "Append a string to esm import paths in rollup",
+  "version": "2.0.0",
+  "description": "Append a string to esm import paths in rollup.",
   "author": "Bryan Ollendyke <mark@epiloque.com>",
   "repository": "https://github.com/elmsln/rollup-rewrite-imports",
   "keywords": [


### PR DESCRIPTION
This now resolves external dependencies by checking if the file exists at the specified rewrite path location.  If it does that the path is rewritten.

I bumped the version to 2.0.0 A major version jump due to the fact that this adds a conditional to figure out which paths to rewrite where before it was rewriting all paths.

Modified the readme file to remove reference to autoExternal which is not needed.